### PR TITLE
feat: import preprocess for images

### DIFF
--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -423,6 +423,18 @@ function makeAbsoluteLinks(main) {
 }
 
 export default {
+  preprocess: ({ document }) => {
+    document.querySelectorAll('img').forEach((img) => {
+      if (img.src && img.src.startsWith('data:')) {
+        const json = img.getAttribute('data-nc-params-imagelazy');
+        if (json) {
+          const params = JSON.parse(json);
+          img.src = params.src;
+        }
+      }
+    });
+  },
+
   /**
    * Apply DOM operations to the provided document and return
    * the root element to be then transformed to Markdown.


### PR DESCRIPTION
Sets the image src before the preprocessing remove them.

Requires https://github.com/adobe/helix-importer/pull/41 and the corresponding cascading releases (helix-importer and helix-importer-ui)