### PR TITLE
fix: fix section naming

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -343,15 +343,15 @@ main .section.dark-blue {
   background-color: var(--c-dark-blue);
 }
 
-main .section.light-gray {
+main .section.light-grey {
   background-color: var(--c-light-gray);
 }
 
-main .section.mid-gray {
+main .section.mid-grey {
   background-color: var(--c-mid-gray);
 }
 
-main .section.dark-gray {
+main .section.dark-grey {
   background-color: var(--c-dark-gray);
 }
 


### PR DESCRIPTION
Fix style name section for meta section which use `...grey` instead of `...gray`

Test URLs:
- Before: https://main--netcentric--hlxsites.hlx.page/our-industries
- After: https://section-style-grey--netcentric--hlxsites.hlx.page/our-industries