### PR TITLE
chore: add light-blue section version for icon-text card

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -55,3 +55,8 @@
     background-color: var(--bg-text-light-plum);
     color: var(--c-dark-plum);
 }
+
+.section.light-blue .cards > ul > li {
+    background-color: var(--bg-text-light-plum);
+    color: var(--c-dark-blue);
+}


### PR DESCRIPTION
Adds another variation of the icons with text with different background
Test URLs:
- Before: https://main--netcentric--hlxsites.hlx.page/drafts/mhaack/icons-text
- After: https://icon-text-blue--netcentric--hlxsites.hlx.page/drafts/mhaack/icons-text
