### PR TITLE
adding embed block for offerings and diversity embeds

### DIFF
--- a/blocks/embed/embed.css
+++ b/blocks/embed/embed.css
@@ -1,0 +1,10 @@
+main .embed {
+    width: unset;
+    text-align: center;
+    max-width: 100%;
+    margin: 16px auto;
+}
+
+main .embed > div {
+    display: block;
+}

--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -1,0 +1,63 @@
+const getDefaultEmbed = (url) => `<div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.25%">
+      <iframe src="${url.href}" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute; overflow: visible;" allowfullscreen=""
+        scrolling="yes" allow="encrypted-media" title="Content from ${url.hostname}" loading="lazy">
+      </iframe>
+    </div>`;
+
+const embedOfferings = (url) => {
+  const embedHTML = `<div style="left: 0; width: 100%; height: 0; position: relative; padding: 65% 0;">
+    <iframe src="${url.href}" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute; overflow: visible;" allowfullscreen=""
+      scrolling="yes" allow="encrypted-media" title="Content from ${url.hostname}" loading="lazy">
+    </iframe>
+  </div>`;
+  return embedHTML;
+};
+
+const embedDiversity = (url) => {
+  const embedHTML = `<div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 42.75%;">
+      <iframe src="${url.href}" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute; overflow: visible;" allowfullscreen=""
+        scrolling="yes" allow="encrypted-media" title="Content from ${url.hostname}" loading="lazy">
+      </iframe>
+    </div>`;
+  return embedHTML;
+};
+
+const loadEmbed = (block, link) => {
+  if (block.classList.contains('embed-is-loaded')) {
+    return;
+  }
+
+  const EMBEDS_CONFIG = [
+    {
+      match: ['offerings'],
+      embed: embedOfferings,
+    },
+    {
+      match: ['diversity'],
+      embed: embedDiversity,
+    },
+  ];
+
+  const config = EMBEDS_CONFIG.find((e) => e.match.some((match) => link.includes(match)));
+  const url = new URL(link);
+  if (config) {
+    block.innerHTML = config.embed(url);
+    block.classList = `block embed embed-${config.match[0]}`;
+  } else {
+    block.innerHTML = getDefaultEmbed(url);
+    block.classList = 'block embed';
+  }
+  block.classList.add('embed-is-loaded');
+};
+
+export default function decorate(block) {
+  const link = block.querySelector('a').href;
+  block.textContent = '';
+  const observer = new IntersectionObserver((entries) => {
+    if (entries.some((e) => e.isIntersecting)) {
+      observer.disconnect();
+      loadEmbed(block, link);
+    }
+  });
+  observer.observe(block);
+}


### PR DESCRIPTION
Adding the iFrame Embed block functionality for "Offerings" and "Diversity" sections.

Fix #54

Test URLs:
- Before: https://main--netcentric--hlxsites.hlx.page/
- After: https://issue-54--netcentric--hlxsites.hlx.page/
