### PR TITLE
#161 leader profiles have correct header color

### DIFF
--- a/blocks/leader-profiles/leader-profiles.css
+++ b/blocks/leader-profiles/leader-profiles.css
@@ -33,6 +33,7 @@
   letter-spacing: -0.5px;
   line-height: 1em;
   margin: 0;
+  color: inherit;
 }
 
 .leader-profiles .leader-profile-heading .icon-chevron-right {


### PR DESCRIPTION
Fix #161 

Test URLs:
- Before: https://main--netcentric--hlxsites.hlx.page/who-we-are
- After: https://161-leader-profiles-name-with-wrong-color--netcentric--hlxsites.hlx.page/who-we-are
