### PR TITLE
#178 link is visible on mid-plum background

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -96,7 +96,7 @@
 
   /* colors */
   --link-color: var(--c-dark-plum);
-  --link-hover-color: var(--c-mid-plum);
+  --link-hover-color: var(--c-dark-mid-plum);
   --background-color: var(--c-white);
   --overlay-background-color: #eee;
   --highlight-background-color: #ccc;


### PR DESCRIPTION

Fix #178 

Test URLs:
- Before: https://main--netcentric--hlxsites.hlx.page/what-we-do/bruker-reference-case
- After: https://178-link-hover-colors-are-incorrect--netcentric--hlxsites.hlx.page/what-we-do/bruker-reference-case
