### PR TITLE
fix: link title tweaks only for non img links

### DIFF
--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -14,6 +14,14 @@ export default async function decorate(block) {
   const html = await resp.text();
   const footer = document.createElement('div');
   footer.innerHTML = html;
+
+  // add link title for all icon only links
+  footer.querySelectorAll('a > span.icon').forEach((icon) => {
+    const a = icon.parentElement;
+    const iconName = icon.classList[1].substring(5, icon.classList[1].length);
+    a.title = a.title || iconName;
+  });
+
   await decorateIcons(footer);
   block.append(footer);
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -37,11 +37,11 @@ export function addChevronToButtons(element, selector = 'a.button') {
  */
 function decorateButtons(element) {
   element.querySelectorAll('a').forEach((a) => {
-    a.title = a.title || a.textContent;
     if (a.href !== a.textContent) {
       const up = a.parentElement;
       const twoup = a.parentElement.parentElement;
       if (!a.querySelector('img')) {
+        a.title = a.title || a.textContent.trim();
         if (up.childNodes.length === 1 && (up.tagName === 'P' || up.tagName === 'DIV')) {
           a.className = 'button'; // default navigational link
           up.classList.add('button-container');


### PR DESCRIPTION
Fix link title handling for links text only.

Fix #192

Before:
![Screenshot 2022-12-06 at 11 08 54](https://user-images.githubusercontent.com/2643450/205882731-9975de2c-e885-4c01-890c-a7da9130a68c.png)

After:
![Screenshot 2022-12-06 at 11 10 27](https://user-images.githubusercontent.com/2643450/205882761-eb0919df-b116-4369-9ecf-38118fae55fa.png)


Test URLs:
- Before: https://main--netcentric--hlxsites.hlx.page/
- After: https://img-title-fix--netcentric--hlxsites.hlx.page/
