### PR TITLE
improved LCP handling

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -284,7 +284,6 @@ export function decorateSections(main) {
  */
 export function updateSectionsStatus(main) {
   const sections = [...main.querySelectorAll(':scope > div.section')];
-  const event = new Event('sectionLoaded');
   for (let i = 0; i < sections.length; i += 1) {
     const section = sections[i];
     const status = section.getAttribute('data-section-status');
@@ -295,7 +294,8 @@ export function updateSectionsStatus(main) {
         break;
       } else {
         section.setAttribute('data-section-status', 'loaded');
-        section.dispatchEvent(event);
+        const event = new CustomEvent('section-display', { detail: { section, numSections: sections.length, sectionIndex: i } });
+        document.body.dispatchEvent(event);
       }
     }
   }
@@ -375,6 +375,8 @@ export async function loadBlock(block) {
       console.log(`failed to load block ${blockName}`, error);
     }
     block.setAttribute('data-block-status', 'loaded');
+    const event = new CustomEvent('block-loaded', { detail: { block, blockName } });
+    document.body.dispatchEvent(event);
   }
 }
 

--- a/scripts/performance.js
+++ b/scripts/performance.js
@@ -75,8 +75,19 @@ function registerPerformanceLogger() {
         stamp(`${entry.name} loaded`, Math.round(entry.startTime + entry.duration));
       });
     });
-
     pores.observe({ type: 'resource', buffered: true });
+
+    document.body.addEventListener('section-display', (e) => {
+      stamp(`section displayed (${e.detail.sectionIndex + 1}/${e.detail.numSections})`, new Date() - performance.timing.navigationStart, 'franklin');
+      // eslint-disable-next-line no-console
+      console.log(e.detail.section);
+    });
+
+    document.body.addEventListener('block-loaded', (e) => {
+      stamp(`block loaded (${e.detail.blockName})`, new Date() - performance.timing.navigationStart, 'franklin');
+      // eslint-disable-next-line no-console
+      console.log(e.detail.block);
+    });
   } catch (e) {
     // no output
   }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -205,7 +205,7 @@ async function loadEager(doc) {
       await waitForLCP(LCP_BLOCKS);
     } else {
       document.querySelector('body').classList.add('appear');
-      // loadGellix();
+      await loadGellix();
     }
   }
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -201,10 +201,10 @@ async function loadEager(doc) {
   if (main) {
     decorateMain(main);
     // await waitForLCP(LCP_BLOCKS);
+    document.querySelector('body').classList.add('appear');
     const gellix = new FontFace('Gellix', 'url("/fonts/gellix-regular_r.woff2")');
     await gellix.load();
     document.fonts.add(gellix);
-    document.querySelector('body').classList.add('appear');
   }
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -9,8 +9,9 @@ import {
   decorateTemplateAndTheme,
   waitForLCP,
   loadBlocks,
+  toClassName,
+  getMetadata,
 } from './lib-franklin.js';
-import { buildBlogFooter } from '../blocks/blog-footer/blog-footer.js';
 
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 window.hlx.RUM_GENERATION = 'project-1'; // add your RUM generation information here
@@ -59,17 +60,6 @@ function decorateButtons(element) {
       }
     }
   });
-}
-
-export function buildBlogSidebar(main) {
-  const blogpost = main.querySelector('.blogpost > main > div:nth-child(2)');
-  if (blogpost === null) {
-    return;
-  }
-
-  const sidebar = document.createElement('div');
-  sidebar.classList.add('blog-sidebar');
-  blogpost.prepend(sidebar);
 }
 
 function buildHeroBlock(main) {
@@ -154,11 +144,17 @@ function preDecorateEmbed(main) {
  * Builds all synthetic blocks in a container element.
  * @param {Element} main The container element
  */
-function buildAutoBlocks(main) {
+async function buildAutoBlocks(main) {
   try {
     buildHeroBlock(main);
-    buildBlogFooter(main);
-    buildBlogSidebar(main);
+    const template = toClassName(getMetadata('template'));
+    const templates = ['blogpost'];
+    if (templates.includes(template)) {
+      const mod = await import(`../templates/${template}/${template}.js`);
+      if (mod.default) {
+        await mod.default(main);
+      }
+    }
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Auto Blocking failed', error);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -9,7 +9,6 @@ import {
   decorateTemplateAndTheme,
   waitForLCP,
   loadBlocks,
-  loadCSS,
 } from './lib-franklin.js';
 import { buildBlogFooter } from '../blocks/blog-footer/blog-footer.js';
 
@@ -200,11 +199,14 @@ async function loadEager(doc) {
   const main = doc.querySelector('main');
   if (main) {
     decorateMain(main);
-    // await waitForLCP(LCP_BLOCKS);
-    document.querySelector('body').classList.add('appear');
-    const gellix = new FontFace('Gellix', 'url("/fonts/gellix-regular_r.woff2")');
-    await gellix.load();
-    document.fonts.add(gellix);
+    if (document.querySelector('main .section:first-child img')) {
+      await waitForLCP(LCP_BLOCKS);
+    } else {
+      document.querySelector('body').classList.add('appear');
+      const gellix = new FontFace('Gellix', 'url("/fonts/gellix-regular_r.woff2")');
+      await gellix.load();
+      document.fonts.add(gellix);
+    }
   }
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -186,6 +186,12 @@ export function decorateMain(main) {
   preDecorateEmbed(main);
 }
 
+async function loadGellix() {
+  const gellix = new FontFace('Gellix', 'url("/fonts/gellix-regular_r.woff2")');
+  await gellix.load();
+  document.fonts.add(gellix);
+}
+
 /**
  * loads everything needed to get to LCP.
  */
@@ -199,9 +205,7 @@ async function loadEager(doc) {
       await waitForLCP(LCP_BLOCKS);
     } else {
       document.querySelector('body').classList.add('appear');
-      const gellix = new FontFace('Gellix', 'url("/fonts/gellix-regular_r.woff2")');
-      await gellix.load();
-      document.fonts.add(gellix);
+      loadGellix();
     }
   }
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -205,7 +205,7 @@ async function loadEager(doc) {
       await waitForLCP(LCP_BLOCKS);
     } else {
       document.querySelector('body').classList.add('appear');
-      loadGellix();
+      // loadGellix();
     }
   }
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -200,7 +200,11 @@ async function loadEager(doc) {
   const main = doc.querySelector('main');
   if (main) {
     decorateMain(main);
-    await waitForLCP(LCP_BLOCKS);
+    // await waitForLCP(LCP_BLOCKS);
+    const gellix = new FontFace('Gellix', 'url("/fonts/gellix-regular_r.woff2")');
+    await gellix.load();
+    document.fonts.add(gellix);
+    document.querySelector('body').classList.add('appear');
   }
 }
 
@@ -235,7 +239,6 @@ async function loadLazy(doc) {
   loadHeader(doc.querySelector('header'));
   loadFooter(doc.querySelector('footer'));
 
-  loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
   addFavIcon(`${window.hlx.codeBasePath}/icons/favicon.ico`);
   sampleRUM('lazy');
   sampleRUM.observe(main.querySelectorAll('div[data-block-name]'));

--- a/templates/blogpost/blogpost.js
+++ b/templates/blogpost/blogpost.js
@@ -1,0 +1,18 @@
+import { buildBlogFooter } from '../../blocks/blog-footer/blog-footer.js';
+
+function buildBlogSidebar(main) {
+  const blogpost = main.querySelector('.blogpost > main > div:nth-child(2)');
+  if (blogpost === null) {
+    return;
+  }
+
+  const sidebar = document.createElement('div');
+  sidebar.classList.add('blog-sidebar');
+  blogpost.prepend(sidebar);
+}
+
+export default function buildAutoBlocks() {
+  const main = document.querySelector('main');
+  buildBlogFooter(main);
+  buildBlogSidebar(main);
+}


### PR DESCRIPTION
most netcentric.biz pages do not have an image based `LCP` which is somewhat unusual and really doesn't work optimally with `LCP` guess in boilerplate code.

i tried to make the code a little bit flexible and replace the bandwidth waiting for `main img` with loading the main font... 
there is some negative impact to the `LCP` (obviously still well within the boundaries of `100`) but both `CLS` and subjective visual stability is greatly improved.

https://rush-font--netcentric--hlxsites.hlx.live/

vs.

https://main--netcentric--hlxsites.hlx.live/

